### PR TITLE
Asus VZ249HE added as not recommended, Acorn RISC OS screen mode/monitor type information

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,7 @@
 
 # VGA tester
 [Pocket-sized tester.](https://github.com/planeturban/15khzvgatester)
+
+# Acorn RISC OS references:
+* [Screen modes](https://www.riscosopen.org/wiki/documentation/show/Screen%20Modes)  
+* [Monitor types](https://www.riscosopen.org/wiki/documentation/show/Monitor%20Types)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 | Asus | VW227D | | 21 | Yes | | |
 | Asus | VE225 | | 22 | Yes | Standard Falcon resolutions too. TT030 works but not centered (for ATARI ST) | |
 | Asus | VH238T | | 23 | Yes | PAL/NTSC/Euro72, correct field order in interlace, no 4:3 aspect setting | |
+| Asus | VZ249H | | 24 | No | Tested on Acorn A3010. Modes 12, 15, 27, 28 and 31 work, mode 39 fails, some Demos fail too. Not Recommended. | |
 | Aydin Controls| SP 1499 | CRT | 13 | Yes | | |
 | Aydin Controls| Spectrum Autosync 9008 | CRT | 20 | Yes | | |
 | Aydin Controls| Spectrum Autosync 9026 | CRT | 28 | Yes | | |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | Asus | VW227D | | 21 | Yes | | |
 | Asus | VE225 | | 22 | Yes | Standard Falcon resolutions too. TT030 works but not centered (for ATARI ST) | |
 | Asus | VH238T | | 23 | Yes | PAL/NTSC/Euro72, correct field order in interlace, no 4:3 aspect setting | |
-| Asus | VZ249H | | 24 | No | Tested on Acorn A3010. Modes 12, 15, 27, 28 and 31 work, mode 39 fails, some Demos fail too. Not Recommended. | |
+| Asus | VZ249HE | | 24 | No | Tested on Acorn A3010. Modes 12, 15, 27, 28 and 31 work, mode 39 fails, some Demos fail too. Not Recommended. | |
 | Aydin Controls| SP 1499 | CRT | 13 | Yes | | |
 | Aydin Controls| Spectrum Autosync 9008 | CRT | 20 | Yes | | |
 | Aydin Controls| Spectrum Autosync 9026 | CRT | 28 | Yes | | |


### PR DESCRIPTION
Asus VZ249HE was suggested as 15kHz capable monitor on https://eab.abime.net/showthread.php?t=85693&page=6 unfortunately that buy was a waste of time.
